### PR TITLE
feat: フッターにブログへのリンクを追加

### DIFF
--- a/belief.html
+++ b/belief.html
@@ -95,8 +95,23 @@
           </div>
           <div class="col-lg-4">
             <h4 class="mb-3">フォローする</h4>
-            <a href="#" class="text-white me-2"><i class="bi bi-twitter"></i></a>
-            <a href="#" class="text-white"><i class="bi bi-facebook"></i></a>
+            <ul class="list-unstyled">
+              <li>
+                <a href="#" class="text-white me-2"
+                  ><i class="bi bi-twitter"></i
+                ></a>
+                <a href="#" class="text-white"><i class="bi bi-facebook"></i></a>
+              </li>
+              <li>
+                <a
+                  href="https://go2senkyo.com/seijika/182527"
+                  class="text-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >ブログを読む</a
+                >
+              </li>
+            </ul>
           </div>
         </div>
         <hr class="my-4" />

--- a/greeting.html
+++ b/greeting.html
@@ -95,8 +95,23 @@
           </div>
           <div class="col-lg-4">
             <h4 class="mb-3">フォローする</h4>
-            <a href="#" class="text-white me-2"><i class="bi bi-twitter"></i></a>
-            <a href="#" class="text-white"><i class="bi bi-facebook"></i></a>
+            <ul class="list-unstyled">
+              <li>
+                <a href="#" class="text-white me-2"
+                  ><i class="bi bi-twitter"></i
+                ></a>
+                <a href="#" class="text-white"><i class="bi bi-facebook"></i></a>
+              </li>
+              <li>
+                <a
+                  href="https://go2senkyo.com/seijika/182527"
+                  class="text-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >ブログを読む</a
+                >
+              </li>
+            </ul>
           </div>
         </div>
         <hr class="my-4" />

--- a/index.html
+++ b/index.html
@@ -230,10 +230,23 @@
           </div>
           <div class="col-lg-4">
             <h4 class="mb-3">フォローする</h4>
-            <a href="#" class="text-white me-2"
-              ><i class="bi bi-twitter"></i
-            ></a>
-            <a href="#" class="text-white"><i class="bi bi-facebook"></i></a>
+            <ul class="list-unstyled">
+              <li>
+                <a href="#" class="text-white me-2"
+                  ><i class="bi bi-twitter"></i
+                ></a>
+                <a href="#" class="text-white"><i class="bi bi-facebook"></i></a>
+              </li>
+              <li>
+                <a
+                  href="https://go2senkyo.com/seijika/182527"
+                  class="text-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >ブログを読む</a
+                >
+              </li>
+            </ul>
           </div>
         </div>
         <hr class="my-4" />

--- a/privacy.html
+++ b/privacy.html
@@ -118,8 +118,23 @@
           </div>
           <div class="col-lg-4">
             <h4 class="mb-3">フォローする</h4>
-            <a href="#" class="text-white me-2"><i class="bi bi-twitter"></i></a>
-            <a href="#" class="text-white"><i class="bi bi-facebook"></i></a>
+            <ul class="list-unstyled">
+              <li>
+                <a href="#" class="text-white me-2"
+                  ><i class="bi bi-twitter"></i
+                ></a>
+                <a href="#" class="text-white"><i class="bi bi-facebook"></i></a>
+              </li>
+              <li>
+                <a
+                  href="https://go2senkyo.com/seijika/182527"
+                  class="text-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >ブログを読む</a
+                >
+              </li>
+            </ul>
           </div>
         </div>
         <hr class="my-4" />


### PR DESCRIPTION
すべてのHTMLページのフッターに「ブログを読む」リンクを追加しました。
このリンクは、ユーザーの要求に応じて外部のブログページを指します。

以下のファイルが変更されました：
- index.html
- greeting.html
- belief.html
- privacy.html

注：各ページのフッターにある連絡先情報に不整合がありますが、これは現在のタスクの範囲外であるため、対処していません。