### PR TITLE
fix: 選挙結果メッセージを中央揃えにする

### DIFF
--- a/style.css
+++ b/style.css
@@ -106,7 +106,7 @@ footer {
 .message-content p {
   font-weight: 700; /* フォントを太くする */
   line-height: 1;   /* 行間を少し広げて読みやすくする */
-  white-space: nowrap;
+  text-align: center;
 }
 
 .signature {


### PR DESCRIPTION
`style.css`の`.message-content p`に`text-align: center;`を追加し、`white-space: nowrap;`を削除しました。 これにより、「今回の選挙結果を受けて」セクションのテキストが正しく中央揃えで表示されるようになります。